### PR TITLE
Fix wrong management of processExitProperly variable - refs #_18708

### DIFF
--- a/plugins/detection-helper-lib/modules/mixinboarddetection.hpp
+++ b/plugins/detection-helper-lib/modules/mixinboarddetection.hpp
@@ -560,7 +560,7 @@ bool MixinBoardDetection<T>::detectBoard(const T& sharedData,
             return true;
         }
 
-        bool isDetected;
+        bool isDetected = false;
         if(!boardDetectionProcess(sharedData, isDetected))
         {
             cancelledOrErrorOccurred = true;

--- a/plugins/segger-jlink-plugin/functions/ajlinkinterface.cpp
+++ b/plugins/segger-jlink-plugin/functions/ajlinkinterface.cpp
@@ -109,6 +109,11 @@ bool AJLinkInterface::callJLinkPgm(const QFile &jLinkScriptFile,
     bool waitForStarted = false;
     bool waitForFinished = false;
 
+    if(processExitProperly != nullptr)
+    {
+        *processExitProperly = false;
+    }
+
     auto tokenStart = connect(&process, &QProcess::started,
                               this, [&waitForStarted]() { waitForStarted = true; });
     auto tokenFinish = connect(&process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
@@ -160,11 +165,6 @@ bool AJLinkInterface::callJLinkPgm(const QFile &jLinkScriptFile,
                                                     .right(ProcessLogCharLimitToDisplay);
             qWarning() << "ErrorOutput: " << process.readAllStandardError()
                                                  .right(ProcessLogCharLimitToDisplay);
-        }
-
-        if(processExitProperly != nullptr)
-        {
-            *processExitProperly = false;
         }
 
         // If processExitProperly is equal to null, it means that the caller has no way to know if

--- a/plugins/segger-jlink-plugin/functions/ajlinkinterface.cpp
+++ b/plugins/segger-jlink-plugin/functions/ajlinkinterface.cpp
@@ -152,7 +152,7 @@ bool AJLinkInterface::callJLinkPgm(const QFile &jLinkScriptFile,
 
     if((process.exitStatus() != QProcess::NormalExit) || (process.exitCode() != 0))
     {
-        if(processExitProperly == nullptr && logProcessError)
+        if(logProcessError)
         {
             qWarning() << "Jlink didn't end as expected : " << process.error()
                        << " Exit code: " << process.exitCode();
@@ -162,12 +162,22 @@ bool AJLinkInterface::callJLinkPgm(const QFile &jLinkScriptFile,
                                                  .right(ProcessLogCharLimitToDisplay);
         }
 
+        if(processExitProperly != nullptr)
+        {
+            *processExitProperly = false;
+        }
+
+        // If processExitProperly is equal to null, it means that the caller has no way to know if
+        // the call has succeeded or not, that's why we return false here.
+        // If processExitProperly is not equal to null, it means that the caller gets the cmd result
+        // throught this variable; therefore we don't return false (which means that a not managed
+        // error has occurred).
         return (processExitProperly != nullptr);
     }
 
     if(processExitProperly != nullptr)
     {
-        *processExitProperly  = true;
+        *processExitProperly = true;
     }
 
     return true;

--- a/plugins/segger-jlink-plugin/functions/ajlinkinterface.hpp
+++ b/plugins/segger-jlink-plugin/functions/ajlinkinterface.hpp
@@ -54,9 +54,9 @@ class AJLinkInterface : public DefaultSequenceInstanceModule
             @param jLinkPgmPath The path to of the JLink program
             @param timeoutInMs The process execution timeout, if -1 the timeout is disabled
             @param logProcessError If true and if an error occured, they will be written in logs
-            @param processExitProperly If not null, this will say if the process exit properly,
+            @param processExitProperly If not null, this will say if the process exits properly,
                                        the param is equals to false except when the process succeeds
-                                       and no error occurs
+                                       and no error occurred
             @return True if no problem occurred */
         bool callJLinkPgm(const QFile &jLinkScriptFile,
                           const QString &jLinkPgmPath,


### PR DESCRIPTION
When the `processExitProperly` parameter value isn't set and an error occurred, the value returned by the parameter was unknown. 